### PR TITLE
Do not rely on global state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -301,7 +301,6 @@ proptest! {
     ) {
       println!("\n=== New Test Run ===\n");
       let mut state = State::default();
-
       let mut executed_commands = Vec::with_capacity(commands.len());
       for cmd in &commands {
           if cmd.command.check(&state) {


### PR DESCRIPTION
Tests (and commands inside) should be autonomous; they should not rely on global state. Initially I moved everything inside State but then I had to fight with the borrow-checker because commands were taking State as parameter but State also had to be mutated across runs. If you see the commits, this journey lead to the creation of two objects, State (mutable) and TestContext (immutable, statically enforced by Rust's type-system). This design is actually great, as it follows the same structure that fast-check uses (where we also have tow types, Model and Real).

I think this PR is a huge win and should be thoroughly reviewed and nitpicked before we consider merging it.