### PR TITLE
Enable command-line replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,8 +141,7 @@ dependencies = [
 [[package]]
 name = "proptest"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+source = "git+https://github.com/proptest-rs/proptest.git?rev=c9bdf18c232665b2b740c667c81866b598d06dc7#c9bdf18c232665b2b740c667c81866b598d06dc7"
 dependencies = [
  "bit-set",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-proptest = "1.6.0"
+proptest = { git = "https://github.com/proptest-rs/proptest.git", rev = "c9bdf18c232665b2b740c667c81866b598d06dc7" }
 
 [[example]]
 name = "integration"


### PR DESCRIPTION
This PR enables replay using seed from the command line by explicitly using [this proptest commit hash](https://github.com/proptest-rs/proptest/commit/b9eb3e4d68729b7fe6b69277332fc99230fb78b3). The `PROPTEST_RNG_SEED` environment variable can be used to run the tests with a specific replay seed.

Example command:

```bash
PROPTEST_RNG_SEED=2000 ./build.sh
```