### PR TITLE
Disable `proptest` default features and explicitly use `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-proptest = "1.6.*"
+proptest = { version = "1.6.*", default-features = false, features = ["std"] }


### PR DESCRIPTION
This PR ensures optional dependencies like `rusty-fork` and `wait-timeout` are not pulled in, reducing `cargo-vet` requirements for projects using `madhouse-rs` and making integration easier without additional dependency auditing.