### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madhouse"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
A stale `Cargo.toml` was mistakenly included in `0.2.1` tag. This PR updates it. Re-tagging will be needed next.